### PR TITLE
Implement generic list framework

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,9 +1,11 @@
 import { configureStore } from "@reduxjs/toolkit";
 import authReducer from "@features/auth/slice";
+import billingGroupReducer from "@features/billing-group/slice";
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
+    billingGroup: billingGroupReducer,
   },
 });
 

--- a/src/features/billing-group/api.ts
+++ b/src/features/billing-group/api.ts
@@ -1,0 +1,10 @@
+import api from "@shared/api/axios";
+
+export const getBillingGroups = async (params: {
+  search: string;
+  filter: string;
+  page: number;
+}) => {
+  const response = await api.get("/billing-groups", { params });
+  return response.data;
+};

--- a/src/features/billing-group/pages/BillingGroupListPage.tsx
+++ b/src/features/billing-group/pages/BillingGroupListPage.tsx
@@ -1,5 +1,24 @@
-import { Card } from "@components/Card";
+import { ListProvider } from "@shared/contexts";
+import { ListPageWrapper } from "@shared/ui/pages";
+import { DataTable, Pagination } from "@shared/ui/components";
+import { useAppSelector } from "@shared/hooks";
+import { fetchBillingGroups } from "../slice";
+
+const columns = [{ header: "Descrição", accessor: "descricao" }];
 
 export default function BillingGroupListPage() {
-  return <Card>Ola</Card>;
+  const { items, total, loading } = useAppSelector((state) => state.billingGroup);
+
+  return (
+    <ListProvider
+      thunk={fetchBillingGroups}
+      filters={["descricao", "vencimento"]}
+      defaultFilter="descricao"
+    >
+      <ListPageWrapper
+        table={<DataTable columns={columns} data={items} loading={loading} />}
+        pagination={<Pagination total={total} />}
+      />
+    </ListProvider>
+  );
 }

--- a/src/features/billing-group/slice.ts
+++ b/src/features/billing-group/slice.ts
@@ -1,0 +1,49 @@
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { getBillingGroups } from "./api";
+
+export interface BillingGroup {
+  id: string;
+  descricao: string;
+}
+
+interface BillingGroupState {
+  items: BillingGroup[];
+  total: number;
+  loading: boolean;
+}
+
+const initialState: BillingGroupState = {
+  items: [],
+  total: 0,
+  loading: false,
+};
+
+export const fetchBillingGroups = createAsyncThunk(
+  "billingGroup/fetch",
+  async (params: { search: string; filter: string; page: number }) => {
+    const data = await getBillingGroups(params);
+    return data as { items: BillingGroup[]; total: number };
+  },
+);
+
+const billingGroupSlice = createSlice({
+  name: "billingGroup",
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchBillingGroups.pending, (state) => {
+        state.loading = true;
+      })
+      .addCase(fetchBillingGroups.fulfilled, (state, action) => {
+        state.loading = false;
+        state.items = action.payload.items;
+        state.total = action.payload.total;
+      })
+      .addCase(fetchBillingGroups.rejected, (state) => {
+        state.loading = false;
+      });
+  },
+});
+
+export default billingGroupSlice.reducer;

--- a/src/shared/contexts/ListContext.tsx
+++ b/src/shared/contexts/ListContext.tsx
@@ -1,0 +1,73 @@
+import type { AsyncThunk } from "@reduxjs/toolkit";
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+} from "react";
+import { useAppDispatch } from "@shared/hooks";
+
+export interface ListContextType {
+  search: string;
+  setSearch: (v: string) => void;
+  filter: string;
+  setFilter: (v: string) => void;
+  page: number;
+  setPage: (v: number) => void;
+  apply: () => void;
+  filters: string[];
+}
+
+interface ListProviderProps {
+  thunk: AsyncThunk<any, { search: string; filter: string; page: number }, any>;
+  filters: string[];
+  defaultFilter: string;
+  children: ReactNode;
+}
+
+const ListContext = createContext<ListContextType | undefined>(undefined);
+
+export function ListProvider({
+  thunk,
+  filters,
+  defaultFilter,
+  children,
+}: ListProviderProps) {
+  const dispatch = useAppDispatch();
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState(defaultFilter);
+  const [page, setPage] = useState(1);
+
+  const apply = useCallback(() => {
+    dispatch(thunk({ search, filter, page }));
+  }, [dispatch, thunk, search, filter, page]);
+
+  useEffect(() => {
+    apply();
+  }, []);
+
+  return (
+    <ListContext.Provider
+      value={{
+        search,
+        setSearch,
+        filter,
+        setFilter,
+        page,
+        setPage,
+        apply,
+        filters,
+      }}
+    >
+      {children}
+    </ListContext.Provider>
+  );
+}
+
+export function useListContext() {
+  const ctx = useContext(ListContext);
+  if (!ctx) throw new Error("useListContext must be inside ListProvider");
+  return ctx;
+}

--- a/src/shared/contexts/index.ts
+++ b/src/shared/contexts/index.ts
@@ -1,0 +1,1 @@
+export * from "./ListContext";

--- a/src/shared/ui/components/ApplyButton.tsx
+++ b/src/shared/ui/components/ApplyButton.tsx
@@ -1,0 +1,12 @@
+import { Button } from "@components/Button";
+import { useListContext } from "@shared/contexts/ListContext";
+
+export default function ApplyButton() {
+  const { apply } = useListContext();
+
+  return (
+    <Button onClick={apply} className="w-auto px-6">
+      Buscar
+    </Button>
+  );
+}

--- a/src/shared/ui/components/DataTable.tsx
+++ b/src/shared/ui/components/DataTable.tsx
@@ -1,0 +1,48 @@
+import { Table } from "@components/Table";
+import type { ReactNode } from "react";
+
+interface Column<T> {
+  header: string;
+  accessor: keyof T | string;
+  render?: (row: T) => ReactNode;
+}
+
+interface DataTableProps<T> {
+  columns: Column<T>[];
+  data: T[];
+  loading?: boolean;
+}
+
+export default function DataTable<T>({
+  columns,
+  data,
+  loading,
+}: DataTableProps<T>) {
+  if (loading) return <div>Carregando...</div>;
+  if (!data?.length) return <div>Nenhum resultado</div>;
+
+  return (
+    <Table className="min-w-full" striped>
+      <thead>
+        <tr>
+          {columns.map((col) => (
+            <th key={col.header} className="px-4 py-2 text-left">
+              {col.header}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row, i) => (
+          <tr key={i}>
+            {columns.map((col) => (
+              <td key={String(col.accessor)} className="px-4 py-2">
+                {col.render ? col.render(row) : (row as any)[col.accessor]}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  );
+}

--- a/src/shared/ui/components/FilterSelect.tsx
+++ b/src/shared/ui/components/FilterSelect.tsx
@@ -1,0 +1,19 @@
+import { useListContext } from "@shared/contexts/ListContext";
+
+export default function FilterSelect() {
+  const { filter, setFilter, filters } = useListContext();
+
+  return (
+    <select
+      value={filter}
+      onChange={(e) => setFilter(e.target.value)}
+      className="h-[50px] px-4 rounded-[16px] border border-gray-200 text-sm"
+    >
+      {filters.map((f) => (
+        <option key={f} value={f}>
+          {f}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/shared/ui/components/Pagination.tsx
+++ b/src/shared/ui/components/Pagination.tsx
@@ -1,0 +1,41 @@
+import { Button } from "@components/Button";
+import { useListContext } from "@shared/contexts/ListContext";
+
+interface PaginationProps {
+  total: number;
+  pageSize?: number;
+}
+
+export default function Pagination({ total, pageSize = 10 }: PaginationProps) {
+  const { page, setPage, apply } = useListContext();
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  const goTo = (p: number) => {
+    setPage(p);
+    apply();
+  };
+
+  return (
+    <div className="flex items-center gap-2 justify-center">
+      <Button
+        onClick={() => goTo(page - 1)}
+        disabled={page <= 1}
+        className="w-auto px-4"
+        mode="outlined"
+      >
+        Anterior
+      </Button>
+      <span className="text-sm text-gray-600">
+        {page} / {totalPages}
+      </span>
+      <Button
+        onClick={() => goTo(page + 1)}
+        disabled={page >= totalPages}
+        className="w-auto px-4"
+        mode="outlined"
+      >
+        Próxima
+      </Button>
+    </div>
+  );
+}

--- a/src/shared/ui/components/SearchInput.tsx
+++ b/src/shared/ui/components/SearchInput.tsx
@@ -1,0 +1,15 @@
+import { Input } from "@components/Input";
+import { useListContext } from "@shared/contexts/ListContext";
+
+export default function SearchInput() {
+  const { search, setSearch } = useListContext();
+
+  return (
+    <Input
+      placeholder="Buscar..."
+      value={search}
+      onChange={(e) => setSearch(e.target.value)}
+      className="w-60"
+    />
+  );
+}

--- a/src/shared/ui/components/index.ts
+++ b/src/shared/ui/components/index.ts
@@ -1,0 +1,5 @@
+export { default as SearchInput } from "./SearchInput";
+export { default as FilterSelect } from "./FilterSelect";
+export { default as ApplyButton } from "./ApplyButton";
+export { default as Pagination } from "./Pagination";
+export { default as DataTable } from "./DataTable";

--- a/src/shared/ui/pages/ListPageWrapper.tsx
+++ b/src/shared/ui/pages/ListPageWrapper.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from "react";
+import SearchInput from "../components/SearchInput";
+import FilterSelect from "../components/FilterSelect";
+import ApplyButton from "../components/ApplyButton";
+
+export interface ListPageWrapperProps {
+  table: ReactNode;
+  pagination: ReactNode;
+}
+
+export default function ListPageWrapper({ table, pagination }: ListPageWrapperProps) {
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-end gap-2 mb-4">
+        <SearchInput />
+        <FilterSelect />
+        <ApplyButton />
+      </div>
+      <div className="flex-1 overflow-y-auto">{table}</div>
+      <div className="mt-4">{pagination}</div>
+    </div>
+  );
+}

--- a/src/shared/ui/pages/index.ts
+++ b/src/shared/ui/pages/index.ts
@@ -1,0 +1,1 @@
+export { default as ListPageWrapper } from "./ListPageWrapper";


### PR DESCRIPTION
## Summary
- add ListContext with typed state
- create reusable list UI components and page wrapper
- implement billing group slice with async fetch
- display billing groups with new ListProvider
- register billingGroup reducer in the store

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c051003c883328228842c4cea6a7d