### PR TITLE
Implement Partners CRUD

### DIFF
--- a/src/app/(admin)/partners/[id]/page.tsx
+++ b/src/app/(admin)/partners/[id]/page.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { Box, Button, Input, VStack, Text } from '@chakra-ui/react';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as yup from 'yup';
+import { useRouter, useParams } from 'next/navigation';
+import {
+  useGetPartnerQuery,
+  useCreatePartnerMutation,
+  useUpdatePartnerMutation,
+} from '@/features/partners/partnersApi';
+
+const schema = yup.object({
+  name: yup.string().required('Nome é obrigatório'),
+  document: yup.string().required('Documento é obrigatório'),
+});
+
+type FormData = yup.InferType<typeof schema>;
+
+export default function PartnerFormPage() {
+  const router = useRouter();
+  const params = useParams();
+  const id = params.id as string;
+  const isNew = id === 'new';
+  const { data } = useGetPartnerQuery(id, { skip: isNew });
+  const [createPartner, { isLoading: creating }] = useCreatePartnerMutation();
+  const [updatePartner, { isLoading: updating }] = useUpdatePartnerMutation();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<FormData>({
+    resolver: yupResolver(schema),
+    defaultValues: { name: '', document: '' },
+  });
+
+  useEffect(() => {
+    if (data) {
+      reset({ name: data.name, document: data.document });
+    }
+  }, [data, reset]);
+
+  const onSubmit = async (formData: FormData) => {
+    try {
+      if (isNew) {
+        await createPartner(formData).unwrap();
+      } else {
+        await updatePartner({ id, ...formData }).unwrap();
+      }
+      router.push('/partners');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleBack = () => {
+    const ok = window.confirm(
+      'As alterações não salvas serão perdidas. Deseja continuar?'
+    );
+    if (ok) router.push('/partners');
+  };
+
+  return (
+    <Box maxW="md" bg="white" p="6" rounded="lg" shadow="sm">
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <VStack gap="4">
+          <Box w="full">
+            <Input placeholder="Nome" {...register('name')} />
+            {errors.name && (
+              <Text color="red.500" fontSize="sm" mt="1">
+                {errors.name.message}
+              </Text>
+            )}
+          </Box>
+          <Box w="full">
+            <Input placeholder="Documento" {...register('document')} />
+            {errors.document && (
+              <Text color="red.500" fontSize="sm" mt="1">
+                {errors.document.message}
+              </Text>
+            )}
+          </Box>
+          <Box display="flex" gap="2" w="full" justifyContent="flex-end">
+            <Button type="button" variant="outline" onClick={handleBack}>
+              Voltar
+            </Button>
+            <Button
+              type="submit"
+              colorScheme="blue"
+              loading={creating || updating}
+            >
+              Salvar
+            </Button>
+          </Box>
+        </VStack>
+      </form>
+    </Box>
+  );
+}

--- a/src/app/(admin)/partners/page.tsx
+++ b/src/app/(admin)/partners/page.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import {
+  Box,
+  IconButton,
+  Skeleton,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  Text,
+} from '@chakra-ui/react';
+import { FiPlus, FiTrash2 } from 'react-icons/fi';
+import { useRouter } from 'next/navigation';
+import {
+  useGetPartnersQuery,
+  useDeletePartnerMutation,
+} from '@/features/partners/partnersApi';
+
+export default function PartnersPage() {
+  const router = useRouter();
+  const { data, isLoading } = useGetPartnersQuery();
+  const [deletePartner] = useDeletePartnerMutation();
+
+  const handleDelete = async (id: string) => {
+    const ok = window.confirm('Tem certeza de que deseja excluir este parceiro?');
+    if (!ok) return;
+    try {
+      await deletePartner(id).unwrap();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <Box position="relative">
+      <Text fontSize="lg" fontWeight="bold" mb="6">
+        Parceiros
+      </Text>
+      {isLoading ? (
+        <Skeleton h="40" />
+      ) : (
+        <Table bg="white" rounded="lg" shadow="sm">
+          <Thead>
+            <Tr>
+              <Th>Nome</Th>
+              <Th>Documento</Th>
+              <Th></Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {data?.map((partner) => (
+              <Tr
+                key={partner.id}
+                _hover={{ bg: 'gray.50' }}
+                cursor="pointer"
+                onClick={() => router.push(`/partners/${partner.id}`)}
+              >
+                <Td>{partner.name}</Td>
+                <Td>{partner.document}</Td>
+                <Td textAlign="right" onClick={(e) => e.stopPropagation()}>
+                  <IconButton
+                    size="sm"
+                    aria-label="Excluir"
+                    icon={<FiTrash2 />}
+                    variant="ghost"
+                    colorScheme="red"
+                    onClick={() => handleDelete(partner.id)}
+                  />
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      )}
+      <IconButton
+        aria-label="Novo"
+        icon={<FiPlus />}
+        position="fixed"
+        bottom="6"
+        right="6"
+        colorScheme="blue"
+        borderRadius="full"
+        size="lg"
+        onClick={() => router.push('/partners/new')}
+      />
+    </Box>
+  );
+}

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Box, Flex, Button, Text } from "@chakra-ui/react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ReactNode } from "react";
 import { useAppDispatch } from "@/store/hooks";
@@ -32,7 +33,14 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
         <Text fontSize="lg" fontWeight="bold" mb="6">
           Boleto Manager
         </Text>
-        {/* future navigation */}
+        <Flex direction="column" gap="2">
+          <Button as={Link} href="/dashboard" variant="ghost" justifyContent="flex-start">
+            Dashboard
+          </Button>
+          <Button as={Link} href="/partners" variant="ghost" justifyContent="flex-start">
+            Partners
+          </Button>
+        </Flex>
       </Box>
       <Flex direction="column" flex="1">
         <Flex

--- a/src/components/ui/provider.tsx
+++ b/src/components/ui/provider.tsx
@@ -7,12 +7,14 @@ import { ColorModeProvider, type ColorModeProviderProps } from "./color-mode";
 import { store } from "@/store";
 import { useAppDispatch } from "@/store/hooks";
 import { hydrateAuth } from "@/features/auth/authSlice";
+import { hydrateApp } from "@/features/app/appSlice";
 
 function SessionLoader({ children }: { children: React.ReactNode }) {
   const dispatch = useAppDispatch();
 
   useEffect(() => {
     dispatch(hydrateAuth());
+    dispatch(hydrateApp());
   }, [dispatch]);
 
   return <>{children}</>;

--- a/src/features/app/appSlice.ts
+++ b/src/features/app/appSlice.ts
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { AppDispatch, RootState } from '@/store';
+
+export interface AppState {
+  selectedPartnerId: string | null;
+}
+
+const initialState: AppState = {
+  selectedPartnerId: null,
+};
+
+const appSlice = createSlice({
+  name: 'app',
+  initialState,
+  reducers: {
+    setSelectedPartnerId(state, action: PayloadAction<string | null>) {
+      state.selectedPartnerId = action.payload;
+    },
+  },
+});
+
+export const { setSelectedPartnerId } = appSlice.actions;
+
+export const selectSelectedPartnerId = (state: RootState) => state.app.selectedPartnerId;
+
+export const hydrateApp = () => (dispatch: AppDispatch) => {
+  const stored = typeof window !== 'undefined' ? localStorage.getItem('selectedPartnerId') : null;
+  if (stored) {
+    dispatch(setSelectedPartnerId(stored));
+  }
+};
+
+export default appSlice.reducer;

--- a/src/features/partners/partnersApi.ts
+++ b/src/features/partners/partnersApi.ts
@@ -1,0 +1,57 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import type { RootState } from '@/store';
+
+export interface Partner {
+  id: string;
+  name: string;
+  document: string;
+}
+
+export const partnersApi = createApi({
+  reducerPath: 'partnersApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: 'http://localhost:3333/v1',
+    prepareHeaders: (headers, { getState }) => {
+      const state = getState() as RootState;
+      const token = state.auth.token;
+      const partnerId = state.app.selectedPartnerId;
+      if (token) headers.set('Authorization', `Bearer ${token}`);
+      if (partnerId) headers.set('x-school-id', partnerId);
+      return headers;
+    },
+  }),
+  tagTypes: ['Partner'],
+  endpoints: (builder) => ({
+    getPartners: builder.query<Partner[], void>({
+      query: () => 'partners',
+      providesTags: ['Partner'],
+    }),
+    getPartner: builder.query<Partner, string>({
+      query: (id) => `partners/${id}`,
+    }),
+    createPartner: builder.mutation<void, Omit<Partner, 'id'>>({
+      query: (data) => ({ url: 'partners', method: 'POST', body: data }),
+      invalidatesTags: ['Partner'],
+    }),
+    updatePartner: builder.mutation<void, Partner>({
+      query: ({ id, ...data }) => ({
+        url: `partners/${id}`,
+        method: 'PUT',
+        body: data,
+      }),
+      invalidatesTags: ['Partner'],
+    }),
+    deletePartner: builder.mutation<void, string>({
+      query: (id) => ({ url: `partners/${id}`, method: 'DELETE' }),
+      invalidatesTags: ['Partner'],
+    }),
+  }),
+});
+
+export const {
+  useGetPartnersQuery,
+  useGetPartnerQuery,
+  useCreatePartnerMutation,
+  useUpdatePartnerMutation,
+  useDeletePartnerMutation,
+} = partnersApi;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,13 +1,18 @@
 import { configureStore } from '@reduxjs/toolkit';
 import authReducer from '@/features/auth/authSlice';
 import { authApi } from '@/features/auth/authApi';
+import appReducer from '@/features/app/appSlice';
+import { partnersApi } from '@/features/partners/partnersApi';
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
+    app: appReducer,
     [authApi.reducerPath]: authApi.reducer,
+    [partnersApi.reducerPath]: partnersApi.reducer,
   },
-  middleware: (gDM) => gDM().concat(authApi.middleware),
+  middleware: (gDM) =>
+    gDM().concat(authApi.middleware, partnersApi.middleware),
 });
 
 export type RootState = ReturnType<typeof store.getState>;


### PR DESCRIPTION
## Summary
- add app slice for storing selected partner
- create partners API with CRUD operations using RTK Query
- hydrate application state on startup
- update Redux store with partners API
- add Partners navigation to dashboard
- implement partners list and form pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686dab2256988332a00409670b520185