### PR TITLE
Add CRUD sections for users, customers and billing groups

### DIFF
--- a/src/app/(admin)/billing-groups/[id]/page.tsx
+++ b/src/app/(admin)/billing-groups/[id]/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { Box, Spinner, useToast } from '@chakra-ui/react';
+import { useRouter, useParams } from 'next/navigation';
+import BillingGroupForm, { BillingGroupFormData } from '@/components/billingGroups/BillingGroupForm';
+import {
+  useCreateBillingGroupMutation,
+  useGetBillingGroupQuery,
+  useUpdateBillingGroupMutation,
+} from '@/features/billingGroups/billingGroupsApi';
+
+export default function BillingGroupFormPage() {
+  const params = useParams();
+  const id = params?.id as string;
+  const isNew = id === 'new';
+  const { data, isLoading } = useGetBillingGroupQuery(id, { skip: isNew });
+  const [createBillingGroup] = useCreateBillingGroupMutation();
+  const [updateBillingGroup] = useUpdateBillingGroupMutation();
+  const router = useRouter();
+  const toast = useToast();
+
+  const handleSubmit = async (values: BillingGroupFormData) => {
+    try {
+      if (isNew) {
+        await createBillingGroup(values).unwrap();
+      } else {
+        await updateBillingGroup({ id, ...values }).unwrap();
+      }
+      toast({ status: 'success', title: 'Salvo com sucesso' });
+      router.push('/billing-groups');
+    } catch {
+      toast({ status: 'error', title: 'Erro ao salvar' });
+    }
+  };
+
+  const handleCancel = () => {
+    if (confirm('As alterações não salvas serão perdidas. Deseja continuar?')) {
+      router.push('/billing-groups');
+    }
+  };
+
+  if (!isNew && isLoading) return <Spinner />;
+
+  return (
+    <Box>
+      <BillingGroupForm
+        defaultValues={data}
+        onSubmit={handleSubmit}
+        onCancel={handleCancel}
+      />
+    </Box>
+  );
+}

--- a/src/app/(admin)/billing-groups/page.tsx
+++ b/src/app/(admin)/billing-groups/page.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { Box, Button, IconButton, List, ListItem, Spinner, Text } from '@chakra-ui/react';
+import { AddIcon, DeleteIcon } from '@chakra-ui/icons';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useGetBillingGroupsQuery, useDeleteBillingGroupMutation } from '@/features/billingGroups/billingGroupsApi';
+
+export default function BillingGroupsPage() {
+  const { data, isLoading } = useGetBillingGroupsQuery();
+  const [deleteBillingGroup] = useDeleteBillingGroupMutation();
+  const router = useRouter();
+
+  const handleDelete = async (id: string) => {
+    if (confirm('Tem certeza de que deseja excluir este registro?')) {
+      await deleteBillingGroup(id);
+    }
+  };
+
+  return (
+    <Box position="relative">
+      <Text fontSize="lg" mb="4">
+        Grupos de Cobrança
+      </Text>
+      {isLoading && <Spinner />}
+      <List spacing="3">
+        {data?.map((bg) => (
+          <ListItem
+            key={bg.id}
+            p="3"
+            bg="white"
+            rounded="md"
+            shadow="sm"
+            display="flex"
+            justifyContent="space-between"
+            alignItems="center"
+            onClick={() => router.push(`/billing-groups/${bg.id}`)}
+            cursor="pointer"
+          >
+            <Text>{`Vencimento dia ${bg.dueDay}`}</Text>
+            <IconButton
+              aria-label="Excluir"
+              icon={<DeleteIcon />}
+              size="sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleDelete(bg.id);
+              }}
+            />
+          </ListItem>
+        ))}
+      </List>
+      <Button
+        position="fixed"
+        bottom="6"
+        right="6"
+        colorScheme="blue"
+        rounded="full"
+        p="0"
+        w="14"
+        h="14"
+        as={Link}
+        href="/billing-groups/new"
+      >
+        <AddIcon />
+      </Button>
+    </Box>
+  );
+}

--- a/src/app/(admin)/customers/[id]/page.tsx
+++ b/src/app/(admin)/customers/[id]/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { Box, Spinner, useToast } from '@chakra-ui/react';
+import { useRouter, useParams } from 'next/navigation';
+import CustomerForm, { CustomerFormData } from '@/components/customers/CustomerForm';
+import {
+  useCreateCustomerMutation,
+  useGetCustomerQuery,
+  useUpdateCustomerMutation,
+} from '@/features/customers/customersApi';
+import { useGetBillingGroupsQuery } from '@/features/billingGroups/billingGroupsApi';
+
+export default function CustomerFormPage() {
+  const params = useParams();
+  const id = params?.id as string;
+  const isNew = id === 'new';
+  const { data, isLoading } = useGetCustomerQuery(id, { skip: isNew });
+  const [createCustomer] = useCreateCustomerMutation();
+  const [updateCustomer] = useUpdateCustomerMutation();
+  const { data: billingGroups } = useGetBillingGroupsQuery();
+  const router = useRouter();
+  const toast = useToast();
+
+  const handleSubmit = async (values: CustomerFormData) => {
+    try {
+      if (isNew) {
+        await createCustomer(values).unwrap();
+      } else {
+        await updateCustomer({ id, ...values }).unwrap();
+      }
+      toast({ status: 'success', title: 'Salvo com sucesso' });
+      router.push('/customers');
+    } catch {
+      toast({ status: 'error', title: 'Erro ao salvar' });
+    }
+  };
+
+  const handleCancel = () => {
+    if (confirm('As alterações não salvas serão perdidas. Deseja continuar?')) {
+      router.push('/customers');
+    }
+  };
+
+  if (!isNew && isLoading) return <Spinner />;
+
+  return (
+    <Box>
+      <CustomerForm
+        defaultValues={data}
+        onSubmit={handleSubmit}
+        onCancel={handleCancel}
+        billingGroups={billingGroups || []}
+      />
+    </Box>
+  );
+}

--- a/src/app/(admin)/customers/page.tsx
+++ b/src/app/(admin)/customers/page.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { Box, Button, IconButton, List, ListItem, Spinner, Text } from '@chakra-ui/react';
+import { AddIcon, DeleteIcon } from '@chakra-ui/icons';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useGetCustomersQuery, useDeleteCustomerMutation } from '@/features/customers/customersApi';
+
+export default function CustomersPage() {
+  const { data, isLoading } = useGetCustomersQuery();
+  const [deleteCustomer] = useDeleteCustomerMutation();
+  const router = useRouter();
+
+  const handleDelete = async (id: string) => {
+    if (confirm('Tem certeza de que deseja excluir este registro?')) {
+      await deleteCustomer(id);
+    }
+  };
+
+  return (
+    <Box position="relative">
+      <Text fontSize="lg" mb="4">
+        Clientes
+      </Text>
+      {isLoading && <Spinner />}
+      <List spacing="3">
+        {data?.map((c) => (
+          <ListItem
+            key={c.id}
+            p="3"
+            bg="white"
+            rounded="md"
+            shadow="sm"
+            display="flex"
+            justifyContent="space-between"
+            alignItems="center"
+            onClick={() => router.push(`/customers/${c.id}`)}
+            cursor="pointer"
+          >
+            <Text>{c.name}</Text>
+            <IconButton
+              aria-label="Excluir"
+              icon={<DeleteIcon />}
+              size="sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleDelete(c.id);
+              }}
+            />
+          </ListItem>
+        ))}
+      </List>
+      <Button
+        position="fixed"
+        bottom="6"
+        right="6"
+        colorScheme="blue"
+        rounded="full"
+        p="0"
+        w="14"
+        h="14"
+        as={Link}
+        href="/customers/new"
+      >
+        <AddIcon />
+      </Button>
+    </Box>
+  );
+}

--- a/src/app/(admin)/users/[id]/page.tsx
+++ b/src/app/(admin)/users/[id]/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { Box, Spinner, useToast } from '@chakra-ui/react';
+import { useRouter, useParams } from 'next/navigation';
+import UserForm, { UserFormData } from '@/components/users/UserForm';
+import {
+  useCreateUserMutation,
+  useGetUserQuery,
+  useUpdateUserMutation,
+} from '@/features/users/usersApi';
+
+export default function UserFormPage() {
+  const params = useParams();
+  const id = params?.id as string;
+  const isNew = id === 'new';
+  const { data, isLoading } = useGetUserQuery(id, { skip: isNew });
+  const [createUser] = useCreateUserMutation();
+  const [updateUser] = useUpdateUserMutation();
+  const router = useRouter();
+  const toast = useToast();
+
+  const handleSubmit = async (values: UserFormData) => {
+    try {
+      if (isNew) {
+        await createUser(values).unwrap();
+      } else {
+        await updateUser({ id, ...values }).unwrap();
+      }
+      toast({ status: 'success', title: 'Salvo com sucesso' });
+      router.push('/users');
+    } catch {
+      toast({ status: 'error', title: 'Erro ao salvar' });
+    }
+  };
+
+  const handleCancel = () => {
+    if (confirm('As alterações não salvas serão perdidas. Deseja continuar?')) {
+      router.push('/users');
+    }
+  };
+
+  if (!isNew && isLoading) return <Spinner />;
+
+  return (
+    <Box>
+      <UserForm
+        defaultValues={data}
+        onSubmit={handleSubmit}
+        onCancel={handleCancel}
+      />
+    </Box>
+  );
+}

--- a/src/app/(admin)/users/page.tsx
+++ b/src/app/(admin)/users/page.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { Box, Button, IconButton, List, ListItem, Spinner, Text } from '@chakra-ui/react';
+import { AddIcon, DeleteIcon } from '@chakra-ui/icons';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useGetUsersQuery, useDeleteUserMutation } from '@/features/users/usersApi';
+
+export default function UsersPage() {
+  const { data, isLoading } = useGetUsersQuery();
+  const [deleteUser] = useDeleteUserMutation();
+  const router = useRouter();
+
+  const handleDelete = async (id: string) => {
+    if (confirm('Tem certeza de que deseja excluir este registro?')) {
+      await deleteUser(id);
+    }
+  };
+
+  return (
+    <Box position="relative">
+      <Text fontSize="lg" mb="4">
+        Usuários
+      </Text>
+      {isLoading && <Spinner />}
+      <List spacing="3">
+        {data?.map((u) => (
+          <ListItem
+            key={u.id}
+            p="3"
+            bg="white"
+            rounded="md"
+            shadow="sm"
+            display="flex"
+            justifyContent="space-between"
+            alignItems="center"
+            onClick={() => router.push(`/users/${u.id}`)}
+            cursor="pointer"
+          >
+            <Text>{u.email}</Text>
+            <IconButton
+              aria-label="Excluir"
+              icon={<DeleteIcon />}
+              size="sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleDelete(u.id);
+              }}
+            />
+          </ListItem>
+        ))}
+      </List>
+      <Button
+        position="fixed"
+        bottom="6"
+        right="6"
+        colorScheme="blue"
+        rounded="full"
+        p="0"
+        w="14"
+        h="14"
+        as={Link}
+        href="/users/new"
+      >
+        <AddIcon />
+      </Button>
+    </Box>
+  );
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -15,7 +15,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
 import { useLoginMutation } from '@/features/auth/authApi';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
-import { setToken, selectToken } from '@/features/auth/authSlice';
+import { setToken, setPartnerId, selectToken } from '@/features/auth/authSlice';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
@@ -51,7 +51,9 @@ export default function LoginPage() {
       const res = await login(data).unwrap();
       const { token } = res;
       dispatch(setToken(token));
+      dispatch(setPartnerId('1'));
       localStorage.setItem('token', token);
+      localStorage.setItem('partnerId', '1');
       router.push('/dashboard');
     } catch (err) {
       console.error(err);

--- a/src/components/billingGroups/BillingGroupForm.tsx
+++ b/src/components/billingGroups/BillingGroupForm.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { Box, Button, Input, VStack, Text } from '@chakra-ui/react';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as yup from 'yup';
+
+export interface BillingGroupFormData {
+  baseAmount: number;
+  dueDay: number;
+  finePercent: number;
+  interestPercentMonth: number;
+}
+
+const schema = yup.object({
+  baseAmount: yup.number().required('Valor base obrigatório'),
+  dueDay: yup.number().required('Dia de vencimento obrigatório'),
+  finePercent: yup.number().required('Multa obrigatória'),
+  interestPercentMonth: yup.number().required('Juros obrigatório'),
+});
+
+interface Props {
+  defaultValues?: BillingGroupFormData;
+  onSubmit: (data: BillingGroupFormData) => void;
+  isLoading?: boolean;
+  onCancel: () => void;
+}
+
+export default function BillingGroupForm({
+  defaultValues,
+  onSubmit,
+  isLoading,
+  onCancel,
+}: Props) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<BillingGroupFormData>({
+    resolver: yupResolver(schema),
+    defaultValues,
+  });
+
+  return (
+    <Box as="form" onSubmit={handleSubmit(onSubmit)}>
+      <VStack gap="4">
+        <Box w="full">
+          <Input type="number" placeholder="Valor Base" {...register('baseAmount', { valueAsNumber: true })} />
+          {errors.baseAmount && (
+            <Text fontSize="sm" color="red.500" mt="1">
+              {errors.baseAmount.message}
+            </Text>
+          )}
+        </Box>
+        <Box w="full">
+          <Input type="number" placeholder="Dia de Vencimento" {...register('dueDay', { valueAsNumber: true })} />
+          {errors.dueDay && (
+            <Text fontSize="sm" color="red.500" mt="1">
+              {errors.dueDay.message}
+            </Text>
+          )}
+        </Box>
+        <Box w="full">
+          <Input type="number" placeholder="% Multa" {...register('finePercent', { valueAsNumber: true })} />
+          {errors.finePercent && (
+            <Text fontSize="sm" color="red.500" mt="1">
+              {errors.finePercent.message}
+            </Text>
+          )}
+        </Box>
+        <Box w="full">
+          <Input type="number" placeholder="% Juros ao Mês" {...register('interestPercentMonth', { valueAsNumber: true })} />
+          {errors.interestPercentMonth && (
+            <Text fontSize="sm" color="red.500" mt="1">
+              {errors.interestPercentMonth.message}
+            </Text>
+          )}
+        </Box>
+        <VStack w="full" align="stretch" gap="2">
+          <Button onClick={onCancel} colorScheme="gray">
+            Voltar
+          </Button>
+          <Button type="submit" colorScheme="blue" isLoading={isLoading}>
+            Salvar
+          </Button>
+        </VStack>
+      </VStack>
+    </Box>
+  );
+}

--- a/src/components/customers/CustomerForm.tsx
+++ b/src/components/customers/CustomerForm.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { Box, Button, Input, VStack, Text, Select } from '@chakra-ui/react';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as yup from 'yup';
+
+export interface CustomerFormData {
+  name: string;
+  document: string;
+  billingGroupId: string;
+}
+
+const schema = yup.object({
+  name: yup.string().required('Nome obrigatório'),
+  document: yup.string().required('Documento obrigatório'),
+  billingGroupId: yup.string().required('Grupo obrigatório'),
+});
+
+interface Props {
+  defaultValues?: CustomerFormData;
+  onSubmit: (data: CustomerFormData) => void;
+  isLoading?: boolean;
+  onCancel: () => void;
+  billingGroups: { id: string; dueDay: number }[];
+}
+
+export default function CustomerForm({
+  defaultValues,
+  onSubmit,
+  isLoading,
+  onCancel,
+  billingGroups,
+}: Props) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<CustomerFormData>({
+    resolver: yupResolver(schema),
+    defaultValues,
+  });
+
+  return (
+    <Box as="form" onSubmit={handleSubmit(onSubmit)}>
+      <VStack gap="4">
+        <Box w="full">
+          <Input placeholder="Nome" {...register('name')} />
+          {errors.name && (
+            <Text fontSize="sm" color="red.500" mt="1">
+              {errors.name.message}
+            </Text>
+          )}
+        </Box>
+        <Box w="full">
+          <Input placeholder="Documento" {...register('document')} />
+          {errors.document && (
+            <Text fontSize="sm" color="red.500" mt="1">
+              {errors.document.message}
+            </Text>
+          )}
+        </Box>
+        <Box w="full">
+          <Select placeholder="Selecione" {...register('billingGroupId')}>
+            {billingGroups.map((bg) => (
+              <option key={bg.id} value={bg.id}>{`Vencimento dia ${bg.dueDay}`}</option>
+            ))}
+          </Select>
+          {errors.billingGroupId && (
+            <Text fontSize="sm" color="red.500" mt="1">
+              {errors.billingGroupId.message}
+            </Text>
+          )}
+        </Box>
+        <VStack w="full" align="stretch" gap="2">
+          <Button onClick={onCancel} colorScheme="gray">
+            Voltar
+          </Button>
+          <Button type="submit" colorScheme="blue" isLoading={isLoading}>
+            Salvar
+          </Button>
+        </VStack>
+      </VStack>
+    </Box>
+  );
+}

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { Box, Flex, Button, Text } from "@chakra-ui/react";
+import { Box, Flex, Button, Text, VStack, Link } from "@chakra-ui/react";
+import NextLink from "next/link";
 import { useRouter } from "next/navigation";
 import { ReactNode } from "react";
 import { useAppDispatch } from "@/store/hooks";
-import { clearToken } from "@/features/auth/authSlice";
+import { clearToken, setPartnerId } from "@/features/auth/authSlice";
 
 interface DashboardLayoutProps {
   children: ReactNode;
@@ -16,7 +17,9 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
 
   const handleLogout = () => {
     dispatch(clearToken());
+    dispatch(setPartnerId(null));
     localStorage.removeItem("token");
+    localStorage.removeItem("partnerId");
     router.push("/login");
   };
 
@@ -32,7 +35,12 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
         <Text fontSize="lg" fontWeight="bold" mb="6">
           Boleto Manager
         </Text>
-        {/* future navigation */}
+        <VStack align="start" spacing="4">
+          <Link as={NextLink} href="/dashboard">Dashboard</Link>
+          <Link as={NextLink} href="/users">Usuários</Link>
+          <Link as={NextLink} href="/customers">Clientes</Link>
+          <Link as={NextLink} href="/billing-groups">Grupos de Cobrança</Link>
+        </VStack>
       </Box>
       <Flex direction="column" flex="1">
         <Flex

--- a/src/components/users/UserForm.tsx
+++ b/src/components/users/UserForm.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { Box, Button, Input, VStack, Text } from '@chakra-ui/react';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as yup from 'yup';
+
+export interface UserFormData {
+  email: string;
+  password?: string;
+}
+
+const schema = yup.object({
+  email: yup.string().required('Email obrigatório').email('Email inválido'),
+  password: yup.string().notRequired(),
+});
+
+interface Props {
+  defaultValues?: UserFormData;
+  onSubmit: (data: UserFormData) => void;
+  isLoading?: boolean;
+  onCancel: () => void;
+}
+
+export default function UserForm({
+  defaultValues,
+  onSubmit,
+  isLoading,
+  onCancel,
+}: Props) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<UserFormData>({
+    resolver: yupResolver(schema),
+    defaultValues,
+  });
+
+  return (
+    <Box as="form" onSubmit={handleSubmit(onSubmit)}>
+      <VStack gap="4">
+        <Box w="full">
+          <Input placeholder="Email" {...register('email')} />
+          {errors.email && (
+            <Text fontSize="sm" color="red.500" mt="1">
+              {errors.email.message}
+            </Text>
+          )}
+        </Box>
+        <Box w="full">
+          <Input type="password" placeholder="Senha" {...register('password')} />
+          {errors.password && (
+            <Text fontSize="sm" color="red.500" mt="1">
+              {errors.password.message}
+            </Text>
+          )}
+        </Box>
+        <VStack w="full" align="stretch" gap="2">
+          <Button onClick={onCancel} colorScheme="gray">
+            Voltar
+          </Button>
+          <Button type="submit" colorScheme="blue" isLoading={isLoading}>
+            Salvar
+          </Button>
+        </VStack>
+      </VStack>
+    </Box>
+  );
+}

--- a/src/features/auth/authSlice.ts
+++ b/src/features/auth/authSlice.ts
@@ -3,10 +3,12 @@ import type { AppDispatch, RootState } from '@/store';
 
 export interface AuthState {
   token: string | null;
+  partnerId: string | null;
 }
 
 const initialState: AuthState = {
   token: null,
+  partnerId: null,
 };
 
 const authSlice = createSlice({
@@ -19,18 +21,23 @@ const authSlice = createSlice({
     clearToken(state) {
       state.token = null;
     },
+    setPartnerId(state, action: PayloadAction<string | null>) {
+      state.partnerId = action.payload;
+    },
   },
 });
 
-export const { setToken, clearToken } = authSlice.actions;
+export const { setToken, clearToken, setPartnerId } = authSlice.actions;
 
 export const selectToken = (state: RootState) => state.auth.token;
+export const selectPartnerId = (state: RootState) => state.auth.partnerId;
 
 export const hydrateAuth = () => (dispatch: AppDispatch) => {
-  const stored = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
-  if (stored) {
-    dispatch(setToken(stored));
-  }
+  if (typeof window === 'undefined') return;
+  const token = localStorage.getItem('token');
+  const partnerId = localStorage.getItem('partnerId');
+  if (token) dispatch(setToken(token));
+  if (partnerId) dispatch(setPartnerId(partnerId));
 };
 
 export default authSlice.reducer;

--- a/src/features/billingGroups/billingGroupsApi.ts
+++ b/src/features/billingGroups/billingGroupsApi.ts
@@ -1,0 +1,64 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import type { RootState } from '@/store';
+
+export interface BillingGroup {
+  id: string;
+  baseAmount: number;
+  dueDay: number;
+  finePercent: number;
+  interestPercentMonth: number;
+  createdBy?: string;
+}
+
+export interface BillingGroupInput {
+  baseAmount: number;
+  dueDay: number;
+  finePercent: number;
+  interestPercentMonth: number;
+  createdBy?: string;
+}
+
+export const billingGroupsApi = createApi({
+  reducerPath: 'billingGroupsApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: 'http://localhost:3333/v1',
+    prepareHeaders: (headers, { getState }) => {
+      const state = getState() as RootState;
+      const token = state.auth.token;
+      const partnerId = state.auth.partnerId;
+      if (token) headers.set('Authorization', `Bearer ${token}`);
+      if (partnerId) headers.set('x-school-id', partnerId);
+      return headers;
+    },
+  }),
+  tagTypes: ['BillingGroup'],
+  endpoints: (builder) => ({
+    getBillingGroups: builder.query<BillingGroup[], void>({
+      query: () => 'billing-groups',
+      providesTags: ['BillingGroup'],
+    }),
+    getBillingGroup: builder.query<BillingGroup, string>({
+      query: (id) => `billing-groups/${id}`,
+    }),
+    createBillingGroup: builder.mutation<BillingGroup, BillingGroupInput>({
+      query: (data) => ({ url: 'billing-groups', method: 'POST', body: data }),
+      invalidatesTags: ['BillingGroup'],
+    }),
+    updateBillingGroup: builder.mutation<BillingGroup, { id: string } & BillingGroupInput>({
+      query: ({ id, ...data }) => ({ url: `billing-groups/${id}`, method: 'PUT', body: data }),
+      invalidatesTags: ['BillingGroup'],
+    }),
+    deleteBillingGroup: builder.mutation<{ deleted: boolean }, string>({
+      query: (id) => ({ url: `billing-groups/${id}`, method: 'DELETE' }),
+      invalidatesTags: ['BillingGroup'],
+    }),
+  }),
+});
+
+export const {
+  useGetBillingGroupsQuery,
+  useGetBillingGroupQuery,
+  useCreateBillingGroupMutation,
+  useUpdateBillingGroupMutation,
+  useDeleteBillingGroupMutation,
+} = billingGroupsApi;

--- a/src/features/customers/customersApi.ts
+++ b/src/features/customers/customersApi.ts
@@ -1,0 +1,60 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import type { RootState } from '@/store';
+
+export interface Customer {
+  id: string;
+  name: string;
+  document: string;
+  billingGroupId: string;
+}
+
+export interface CustomerInput {
+  name: string;
+  document: string;
+  billingGroupId: string;
+}
+
+export const customersApi = createApi({
+  reducerPath: 'customersApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: 'http://localhost:3333/v1',
+    prepareHeaders: (headers, { getState }) => {
+      const state = getState() as RootState;
+      const token = state.auth.token;
+      const partnerId = state.auth.partnerId;
+      if (token) headers.set('Authorization', `Bearer ${token}`);
+      if (partnerId) headers.set('x-school-id', partnerId);
+      return headers;
+    },
+  }),
+  tagTypes: ['Customer'],
+  endpoints: (builder) => ({
+    getCustomers: builder.query<Customer[], void>({
+      query: () => 'customers',
+      providesTags: ['Customer'],
+    }),
+    getCustomer: builder.query<Customer, string>({
+      query: (id) => `customers/${id}`,
+    }),
+    createCustomer: builder.mutation<Customer, CustomerInput>({
+      query: (data) => ({ url: 'customers', method: 'POST', body: data }),
+      invalidatesTags: ['Customer'],
+    }),
+    updateCustomer: builder.mutation<Customer, { id: string } & CustomerInput>({
+      query: ({ id, ...data }) => ({ url: `customers/${id}`, method: 'PUT', body: data }),
+      invalidatesTags: ['Customer'],
+    }),
+    deleteCustomer: builder.mutation<{ deleted: boolean }, string>({
+      query: (id) => ({ url: `customers/${id}`, method: 'DELETE' }),
+      invalidatesTags: ['Customer'],
+    }),
+  }),
+});
+
+export const {
+  useGetCustomersQuery,
+  useGetCustomerQuery,
+  useCreateCustomerMutation,
+  useUpdateCustomerMutation,
+  useDeleteCustomerMutation,
+} = customersApi;

--- a/src/features/users/usersApi.ts
+++ b/src/features/users/usersApi.ts
@@ -1,0 +1,57 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import type { RootState } from '@/store';
+
+export interface User {
+  id: string;
+  email: string;
+}
+
+export interface UserInput {
+  email: string;
+  password?: string;
+}
+
+export const usersApi = createApi({
+  reducerPath: 'usersApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: 'http://localhost:3333/v1',
+    prepareHeaders: (headers, { getState }) => {
+      const state = getState() as RootState;
+      const token = state.auth.token;
+      const partnerId = state.auth.partnerId;
+      if (token) headers.set('Authorization', `Bearer ${token}`);
+      if (partnerId) headers.set('x-school-id', partnerId);
+      return headers;
+    },
+  }),
+  tagTypes: ['User'],
+  endpoints: (builder) => ({
+    getUsers: builder.query<User[], void>({
+      query: () => 'users',
+      providesTags: ['User'],
+    }),
+    getUser: builder.query<User, string>({
+      query: (id) => `users/${id}`,
+    }),
+    createUser: builder.mutation<User, UserInput>({
+      query: (data) => ({ url: 'users', method: 'POST', body: data }),
+      invalidatesTags: ['User'],
+    }),
+    updateUser: builder.mutation<User, { id: string } & UserInput>({
+      query: ({ id, ...data }) => ({ url: `users/${id}`, method: 'PUT', body: data }),
+      invalidatesTags: ['User'],
+    }),
+    deleteUser: builder.mutation<{ deleted: boolean }, string>({
+      query: (id) => ({ url: `users/${id}`, method: 'DELETE' }),
+      invalidatesTags: ['User'],
+    }),
+  }),
+});
+
+export const {
+  useGetUsersQuery,
+  useGetUserQuery,
+  useCreateUserMutation,
+  useUpdateUserMutation,
+  useDeleteUserMutation,
+} = usersApi;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,13 +1,25 @@
 import { configureStore } from '@reduxjs/toolkit';
 import authReducer from '@/features/auth/authSlice';
 import { authApi } from '@/features/auth/authApi';
+import { usersApi } from '@/features/users/usersApi';
+import { customersApi } from '@/features/customers/customersApi';
+import { billingGroupsApi } from '@/features/billingGroups/billingGroupsApi';
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
     [authApi.reducerPath]: authApi.reducer,
+    [usersApi.reducerPath]: usersApi.reducer,
+    [customersApi.reducerPath]: customersApi.reducer,
+    [billingGroupsApi.reducerPath]: billingGroupsApi.reducer,
   },
-  middleware: (gDM) => gDM().concat(authApi.middleware),
+  middleware: (gDM) =>
+    gDM().concat(
+      authApi.middleware,
+      usersApi.middleware,
+      customersApi.middleware,
+      billingGroupsApi.middleware,
+    ),
 });
 
 export type RootState = ReturnType<typeof store.getState>;


### PR DESCRIPTION
## Summary
- implement RTK Query API slices for users, customers and billing groups
- store selected partner id in auth slice
- register new API slices in Redux store
- add navigation links in dashboard layout
- create forms and pages for each CRUD
- preload auth/partner id from localStorage and set headers on requests

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686e6535a8e48332be3cf19eb15d0611