### PR TITLE
Implement settings page

### DIFF
--- a/src/app/(admin)/settings/layout.tsx
+++ b/src/app/(admin)/settings/layout.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { Toaster } from '@/components/ui/toaster';
+
+export default function SettingsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      <Toaster />
+    </>
+  );
+}

--- a/src/app/(admin)/settings/page.tsx
+++ b/src/app/(admin)/settings/page.tsx
@@ -1,0 +1,289 @@
+'use client';
+
+import {
+  Box,
+  Button,
+  Field,
+  Flex,
+  Heading,
+  Input,
+  List,
+  Stack,
+  Tabs,
+} from '@chakra-ui/react';
+import { useState, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as yup from 'yup';
+import {
+  useGetPartnersQuery,
+  useCreatePartnerMutation,
+  useUpdatePartnerMutation,
+  useDeletePartnerMutation,
+  useGetProvidersQuery,
+  useCreateProviderMutation,
+  useUpdateProviderMutation,
+  useDeleteProviderMutation,
+  type Partner,
+  type Provider,
+} from '@/features/settings/settingsApi';
+import { toaster } from '@/components/ui/toaster';
+
+function PartnerSection() {
+  const { data: partners = [], refetch } = useGetPartnersQuery();
+  const [createPartner] = useCreatePartnerMutation();
+  const [updatePartner] = useUpdatePartnerMutation();
+  const [deletePartner] = useDeletePartnerMutation();
+  const [selected, setSelected] = useState<Partner | null>(null);
+
+  const schema = yup.object({
+    name: yup.string().required('Nome \u00e9 obrigat\u00f3rio'),
+  });
+  type FormData = yup.InferType<typeof schema>;
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: yupResolver(schema),
+    defaultValues: { name: '' },
+  });
+
+  useEffect(() => {
+    if (selected) {
+      reset({ name: selected.name });
+    } else {
+      reset({ name: '' });
+    }
+  }, [selected, reset]);
+
+  const onSubmit = async (data: FormData) => {
+    try {
+      if (selected) {
+        await updatePartner({ id: selected.id, data }).unwrap();
+      } else {
+        await createPartner(data).unwrap();
+      }
+      toaster.create({ title: 'Registro salvo com sucesso' });
+      setSelected(null);
+      refetch();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!selected) return;
+    const ok = window.confirm('Tem certeza de que deseja remover este registro?');
+    if (ok) {
+      try {
+        await deletePartner(selected.id).unwrap();
+        toaster.create({ title: 'Registro removido com sucesso' });
+        setSelected(null);
+        refetch();
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  };
+
+  return (
+    <Box>
+      <Heading size="sm" mb="4">
+        Parceiros
+      </Heading>
+      <Flex gap="8" align="flex-start">
+        <Box w="xs">
+          <List.Root borderWidth="1px" rounded="md" overflow="hidden">
+            {partners.map((p) => (
+              <List.Item
+                key={p.id}
+                px="3"
+                py="2"
+                cursor="pointer"
+                bg={selected?.id === p.id ? 'gray.100' : undefined}
+                _hover={{ bg: 'gray.100' }}
+                onClick={() => setSelected(p)}
+              >
+                {p.name}
+              </List.Item>
+            ))}
+          </List.Root>
+        </Box>
+        <Box flex="1">
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <Stack gap="4">
+              <Field.Root invalid={!!errors.name}>
+                <Field.Label>Nome</Field.Label>
+                <Input {...register('name')} />
+                {errors.name && (
+                  <Field.ErrorText>{errors.name.message}</Field.ErrorText>
+                )}
+              </Field.Root>
+              <Flex gap="2">
+                <Button type="button" onClick={() => setSelected(null)}>
+                  Adicionar
+                </Button>
+                <Button type="submit" colorScheme="blue">
+                  Salvar
+                </Button>
+                <Button
+                  type="button"
+                  colorScheme="red"
+                  onClick={handleDelete}
+                  isDisabled={!selected}
+                >
+                  Remover
+                </Button>
+              </Flex>
+            </Stack>
+          </form>
+        </Box>
+      </Flex>
+    </Box>
+  );
+}
+
+function ProviderSection() {
+  const { data: providers = [], refetch } = useGetProvidersQuery();
+  const [createProvider] = useCreateProviderMutation();
+  const [updateProvider] = useUpdateProviderMutation();
+  const [deleteProvider] = useDeleteProviderMutation();
+  const [selected, setSelected] = useState<Provider | null>(null);
+
+  const schema = yup.object({
+    code: yup.string().required('C\u00f3digo \u00e9 obrigat\u00f3rio'),
+    name: yup.string().required('Nome \u00e9 obrigat\u00f3rio'),
+  });
+  type FormData = yup.InferType<typeof schema>;
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: yupResolver(schema),
+    defaultValues: { code: '', name: '' },
+  });
+
+  useEffect(() => {
+    if (selected) {
+      reset({ code: selected.code, name: selected.name });
+    } else {
+      reset({ code: '', name: '' });
+    }
+  }, [selected, reset]);
+
+  const onSubmit = async (data: FormData) => {
+    try {
+      if (selected) {
+        await updateProvider({ id: selected.id, data }).unwrap();
+      } else {
+        await createProvider(data).unwrap();
+      }
+      toaster.create({ title: 'Registro salvo com sucesso' });
+      setSelected(null);
+      refetch();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!selected) return;
+    const ok = window.confirm('Tem certeza de que deseja remover este registro?');
+    if (ok) {
+      try {
+        await deleteProvider(selected.id).unwrap();
+        toaster.create({ title: 'Registro removido com sucesso' });
+        setSelected(null);
+        refetch();
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  };
+
+  return (
+    <Box>
+      <Heading size="sm" mb="4">
+        Fornecedores
+      </Heading>
+      <Flex gap="8" align="flex-start">
+        <Box w="xs">
+          <List.Root borderWidth="1px" rounded="md" overflow="hidden">
+            {providers.map((p) => (
+              <List.Item
+                key={p.id}
+                px="3"
+                py="2"
+                cursor="pointer"
+                bg={selected?.id === p.id ? 'gray.100' : undefined}
+                _hover={{ bg: 'gray.100' }}
+                onClick={() => setSelected(p)}
+              >
+                {p.name}
+              </List.Item>
+            ))}
+          </List.Root>
+        </Box>
+        <Box flex="1">
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <Stack gap="4">
+              <Field.Root invalid={!!errors.code}>
+                <Field.Label>C\u00f3digo</Field.Label>
+                <Input {...register('code')} />
+                {errors.code && (
+                  <Field.ErrorText>{errors.code.message}</Field.ErrorText>
+                )}
+              </Field.Root>
+              <Field.Root invalid={!!errors.name}>
+                <Field.Label>Nome</Field.Label>
+                <Input {...register('name')} />
+                {errors.name && (
+                  <Field.ErrorText>{errors.name.message}</Field.ErrorText>
+                )}
+              </Field.Root>
+              <Flex gap="2">
+                <Button type="button" onClick={() => setSelected(null)}>
+                  Adicionar
+                </Button>
+                <Button type="submit" colorScheme="blue">
+                  Salvar
+                </Button>
+                <Button
+                  type="button"
+                  colorScheme="red"
+                  onClick={handleDelete}
+                  isDisabled={!selected}
+                >
+                  Remover
+                </Button>
+              </Flex>
+            </Stack>
+          </form>
+        </Box>
+      </Flex>
+    </Box>
+  );
+}
+
+export default function SettingsPage() {
+  return (
+    <Tabs.Root defaultValue="entidades">
+      <Tabs.List mb="4">
+        <Tabs.Trigger value="entidades">Entidades auxiliares</Tabs.Trigger>
+        <Tabs.Indicator />
+      </Tabs.List>
+      <Tabs.Content value="entidades">
+        <Stack gap="10">
+          <PartnerSection />
+          <ProviderSection />
+        </Stack>
+      </Tabs.Content>
+    </Tabs.Root>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html suppressHydrationWarning>
+    <html lang={'pt-br'} suppressHydrationWarning>
       <body>
         <Provider>{children}</Provider>
       </body>

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Box, Flex, Button, Text } from "@chakra-ui/react";
-import { useRouter } from "next/navigation";
+import { Box, Flex, Button, Text, Stack, Link } from "@chakra-ui/react";
+import NextLink from "next/link";
+import { usePathname, useRouter } from "next/navigation";
 import { ReactNode } from "react";
 import { useAppDispatch } from "@/store/hooks";
 import { clearToken } from "@/features/auth/authSlice";
@@ -13,6 +14,9 @@ interface DashboardLayoutProps {
 export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const dispatch = useAppDispatch();
   const router = useRouter();
+  const pathname = usePathname();
+
+  const pageTitle = pathname.startsWith("/settings") ? "Configuraçoes" : "Dashboard";
 
   const handleLogout = () => {
     dispatch(clearToken());
@@ -32,7 +36,14 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
         <Text fontSize="lg" fontWeight="bold" mb="6">
           Boleto Manager
         </Text>
-        {/* future navigation */}
+        <Stack as="nav" gap="2">
+          <Link asChild color={pathname === "/dashboard" ? "blue.600" : undefined}>
+            <NextLink href="/dashboard">Dashboard</NextLink>
+          </Link>
+          <Link asChild color={pathname.startsWith("/settings") ? "blue.600" : undefined}>
+            <NextLink href="/settings">Configuração</NextLink>
+          </Link>
+        </Stack>
       </Box>
       <Flex direction="column" flex="1">
         <Flex
@@ -44,7 +55,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
           borderBottomWidth="1px"
           bg="white"
         >
-          <Text fontWeight="medium">Dashboard</Text>
+          <Text fontWeight="medium">{pageTitle}</Text>
           <Button size="sm" onClick={handleLogout} colorScheme="red">
             Sair
           </Button>

--- a/src/features/app/appSlice.ts
+++ b/src/features/app/appSlice.ts
@@ -1,0 +1,27 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { RootState } from '@/store';
+
+export interface AppState {
+  selectedPartnerId: string | null;
+}
+
+const initialState: AppState = {
+  selectedPartnerId: null,
+};
+
+const appSlice = createSlice({
+  name: 'app',
+  initialState,
+  reducers: {
+    setSelectedPartnerId(state, action: PayloadAction<string | null>) {
+      state.selectedPartnerId = action.payload;
+    },
+  },
+});
+
+export const { setSelectedPartnerId } = appSlice.actions;
+
+export const selectSelectedPartnerId = (state: RootState) =>
+  state.app.selectedPartnerId;
+
+export default appSlice.reducer;

--- a/src/features/settings/settingsApi.ts
+++ b/src/features/settings/settingsApi.ts
@@ -1,0 +1,105 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import type { RootState } from '@/store';
+
+export interface Partner {
+  id: string;
+  name: string;
+  createdBy?: string;
+}
+
+export interface Provider {
+  id: string;
+  code: string;
+  name: string;
+}
+
+export const settingsApi = createApi({
+  reducerPath: 'settingsApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: 'http://localhost:3333/v1',
+    prepareHeaders: (headers, { getState }) => {
+      const state = getState() as RootState;
+      const token = state.auth.token;
+      const partnerId = state.app.selectedPartnerId;
+      if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+      }
+      if (partnerId) {
+        headers.set('x-school-id', partnerId);
+      }
+      return headers;
+    },
+  }),
+  tagTypes: ['Partner', 'Provider'],
+  endpoints: (builder) => ({
+    getPartners: builder.query<Partner[], void>({
+      query: () => 'partners',
+      providesTags: ['Partner'],
+    }),
+    createPartner: builder.mutation<Partner, Pick<Partner, 'name'>>({
+      query: (body) => ({
+        url: 'partners',
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: ['Partner'],
+    }),
+    updatePartner: builder.mutation<Partner, { id: string; data: Pick<Partner, 'name'> }>(
+      {
+        query: ({ id, data }) => ({
+          url: `partners/${id}`,
+          method: 'PUT',
+          body: data,
+        }),
+        invalidatesTags: ['Partner'],
+      }
+    ),
+    deletePartner: builder.mutation<void, string>({
+      query: (id) => ({
+        url: `partners/${id}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: ['Partner'],
+    }),
+    getProviders: builder.query<Provider[], void>({
+      query: () => 'providers',
+      providesTags: ['Provider'],
+    }),
+    createProvider: builder.mutation<Provider, Pick<Provider, 'code' | 'name'>>({
+      query: (body) => ({
+        url: 'providers',
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: ['Provider'],
+    }),
+    updateProvider: builder.mutation<Provider, { id: string; data: Pick<Provider, 'code' | 'name'> }>(
+      {
+        query: ({ id, data }) => ({
+          url: `providers/${id}`,
+          method: 'PUT',
+          body: data,
+        }),
+        invalidatesTags: ['Provider'],
+      }
+    ),
+    deleteProvider: builder.mutation<void, string>({
+      query: (id) => ({
+        url: `providers/${id}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: ['Provider'],
+    }),
+  }),
+});
+
+export const {
+  useGetPartnersQuery,
+  useCreatePartnerMutation,
+  useUpdatePartnerMutation,
+  useDeletePartnerMutation,
+  useGetProvidersQuery,
+  useCreateProviderMutation,
+  useUpdateProviderMutation,
+  useDeleteProviderMutation,
+} = settingsApi;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,13 +1,18 @@
 import { configureStore } from '@reduxjs/toolkit';
 import authReducer from '@/features/auth/authSlice';
 import { authApi } from '@/features/auth/authApi';
+import appReducer from '@/features/app/appSlice';
+import { settingsApi } from '@/features/settings/settingsApi';
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
+    app: appReducer,
     [authApi.reducerPath]: authApi.reducer,
+    [settingsApi.reducerPath]: settingsApi.reducer,
   },
-  middleware: (gDM) => gDM().concat(authApi.middleware),
+  middleware: (gDM) =>
+    gDM().concat(authApi.middleware, settingsApi.middleware),
 });
 
 export type RootState = ReturnType<typeof store.getState>;


### PR DESCRIPTION
## Summary
- add slice for selected partner
- add RTK Query settings API for partners and providers
- extend store with new reducers and middleware
- update DashboardLayout with navigation and dynamic title
- add settings page with tabbed interface to manage partners and providers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686eb8a086488332b4b8dfaa2f138165