### PR TITLE
Add CRUD table modules

### DIFF
--- a/src/app/(admin)/billing-groups/BillingGroupForm.tsx
+++ b/src/app/(admin)/billing-groups/BillingGroupForm.tsx
@@ -1,0 +1,69 @@
+'use client';
+import { Button, Field, Input, Stack } from '@chakra-ui/react';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as yup from 'yup';
+
+const schema = yup.object({
+  baseAmount: yup.number().required('Valor é obrigatório'),
+  dueDay: yup.number().required('Vencimento é obrigatório'),
+  finePercent: yup.number().required('Multa é obrigatória'),
+  interestPercentMonth: yup.number().required('Juros é obrigatório'),
+});
+
+export type BillingGroupFormData = yup.InferType<typeof schema>;
+
+export default function BillingGroupForm({
+  defaultValues,
+  onSubmit,
+}: {
+  defaultValues?: Partial<BillingGroupFormData>;
+  onSubmit: (data: BillingGroupFormData) => void;
+}) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<BillingGroupFormData>({
+    resolver: yupResolver(schema),
+    defaultValues,
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Stack gap="4" maxW="sm">
+        <Field.Root invalid={!!errors.baseAmount}>
+          <Field.Label>Valor base</Field.Label>
+          <Input type="number" {...register('baseAmount', { valueAsNumber: true })} />
+          {errors.baseAmount && (
+            <Field.ErrorText>{errors.baseAmount.message}</Field.ErrorText>
+          )}
+        </Field.Root>
+        <Field.Root invalid={!!errors.dueDay}>
+          <Field.Label>Dia de vencimento</Field.Label>
+          <Input type="number" {...register('dueDay', { valueAsNumber: true })} />
+          {errors.dueDay && (
+            <Field.ErrorText>{errors.dueDay.message}</Field.ErrorText>
+          )}
+        </Field.Root>
+        <Field.Root invalid={!!errors.finePercent}>
+          <Field.Label>Multa (%)</Field.Label>
+          <Input type="number" {...register('finePercent', { valueAsNumber: true })} />
+          {errors.finePercent && (
+            <Field.ErrorText>{errors.finePercent.message}</Field.ErrorText>
+          )}
+        </Field.Root>
+        <Field.Root invalid={!!errors.interestPercentMonth}>
+          <Field.Label>Juros (% mês)</Field.Label>
+          <Input type="number" {...register('interestPercentMonth', { valueAsNumber: true })} />
+          {errors.interestPercentMonth && (
+            <Field.ErrorText>{errors.interestPercentMonth.message}</Field.ErrorText>
+          )}
+        </Field.Root>
+        <Button type="submit" colorScheme="blue">
+          Salvar
+        </Button>
+      </Stack>
+    </form>
+  );
+}

--- a/src/app/(admin)/billing-groups/[id]/page.tsx
+++ b/src/app/(admin)/billing-groups/[id]/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { Box } from '@chakra-ui/react';
+import { useRouter, useParams } from 'next/navigation';
+import BillingGroupForm, { BillingGroupFormData } from '../BillingGroupForm';
+import {
+  useGetBillingGroupQuery,
+  useUpdateBillingGroupMutation,
+} from '@/features/billingGroups/billingGroupsApi';
+
+export default function EditBillingGroupPage() {
+  const params = useParams();
+  const id = params?.id as string;
+  const { data } = useGetBillingGroupQuery(id);
+  const [updateGroup] = useUpdateBillingGroupMutation();
+  const router = useRouter();
+
+  const handleSubmit = async (form: BillingGroupFormData) => {
+    await updateGroup({ id, data: form }).unwrap();
+    router.push('/billing-groups');
+  };
+
+  if (!data) return null;
+
+  return (
+    <Box>
+      <BillingGroupForm
+        onSubmit={handleSubmit}
+        defaultValues={{
+          baseAmount: data.baseAmount,
+          dueDay: data.dueDay,
+          finePercent: data.finePercent,
+          interestPercentMonth: data.interestPercentMonth,
+        }}
+      />
+    </Box>
+  );
+}

--- a/src/app/(admin)/billing-groups/new/page.tsx
+++ b/src/app/(admin)/billing-groups/new/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { Box } from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
+import BillingGroupForm, { BillingGroupFormData } from '../BillingGroupForm';
+import { useCreateBillingGroupMutation } from '@/features/billingGroups/billingGroupsApi';
+
+export default function NewBillingGroupPage() {
+  const [createGroup] = useCreateBillingGroupMutation();
+  const router = useRouter();
+
+  const handleSubmit = async (data: BillingGroupFormData) => {
+    await createGroup(data).unwrap();
+    router.push('/billing-groups');
+  };
+
+  return (
+    <Box>
+      <BillingGroupForm onSubmit={handleSubmit} />
+    </Box>
+  );
+}

--- a/src/app/(admin)/billing-groups/page.tsx
+++ b/src/app/(admin)/billing-groups/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+import { Box, Button } from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import DataTable from '@/components/DataTable';
+import Search from '@/components/Search';
+import PaginationAction from '@/components/PaginationAction';
+import {
+  useGetBillingGroupsQuery,
+  useDeleteBillingGroupMutation,
+} from '@/features/billingGroups/billingGroupsApi';
+
+export default function BillingGroupsPage() {
+  const { data = [] } = useGetBillingGroupsQuery();
+  const [deleteGroup] = useDeleteBillingGroupMutation();
+  const router = useRouter();
+  const [page, setPage] = useState(1);
+  const pageSize = 10;
+  const totalCount = data.length;
+
+  return (
+    <Box position="relative">
+      <Search
+        options={[{ key: 'id', label: 'ID' }]}
+        defaultKey="id"
+        onSearch={() => {}}
+      />
+      <DataTable
+        data={data.slice((page - 1) * pageSize, page * pageSize)}
+        options={[
+          { key: 'baseAmount', label: 'Valor' },
+          { key: 'dueDay', label: 'Vencimento' },
+        ]}
+        onRowClick={(id) => router.push(`/billing-groups/${id}`)}
+        onDelete={async (id) => {
+          await deleteGroup(id);
+        }}
+        page={page}
+        pageSize={pageSize}
+        totalCount={totalCount}
+      />
+      <PaginationAction
+        page={page}
+        pageSize={pageSize}
+        totalCount={totalCount}
+        onPageChange={setPage}
+      />
+      <Button
+        position="fixed"
+        bottom="8"
+        right="8"
+        colorScheme="blue"
+        rounded="full"
+        onClick={() => router.push('/billing-groups/new')}
+      >
+        +
+      </Button>
+    </Box>
+  );
+}

--- a/src/app/(admin)/billing-groups/page.tsx
+++ b/src/app/(admin)/billing-groups/page.tsx
@@ -26,11 +26,14 @@ export default function BillingGroupsPage() {
         onSearch={() => {}}
       />
       <DataTable
-        data={data.slice((page - 1) * pageSize, page * pageSize)}
+        data={data
+          .slice((page - 1) * pageSize, page * pageSize)
+          .map((g) => g as unknown as Record<string, string>)}
         options={[
-          { key: 'baseAmount', label: 'Valor' },
-          { key: 'dueDay', label: 'Vencimento' },
+          { key: 'baseAmount', columName: 'Valor' },
+          { key: 'dueDay', columName: 'Vencimento' },
         ]}
+        keyExtractor={(g) => g.id}
         onRowClick={(id) => router.push(`/billing-groups/${id}`)}
         onDelete={async (id) => {
           await deleteGroup(id);

--- a/src/app/(admin)/customers/CustomerForm.tsx
+++ b/src/app/(admin)/customers/CustomerForm.tsx
@@ -1,0 +1,59 @@
+'use client';
+import { Button, Field, Input, Stack } from '@chakra-ui/react';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as yup from 'yup';
+
+const schema = yup.object({
+  name: yup.string().required('Nome é obrigatório'),
+  document: yup.string().required('Documento é obrigatório'),
+  billingGroupId: yup.string().required('Grupo é obrigatório'),
+});
+
+export type CustomerFormData = yup.InferType<typeof schema>;
+
+export default function CustomerForm({
+  defaultValues,
+  onSubmit,
+}: {
+  defaultValues?: Partial<CustomerFormData>;
+  onSubmit: (data: CustomerFormData) => void;
+}) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<CustomerFormData>({
+    resolver: yupResolver(schema),
+    defaultValues,
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Stack gap="4" maxW="sm">
+        <Field.Root invalid={!!errors.name}>
+          <Field.Label>Nome</Field.Label>
+          <Input {...register('name')} />
+          {errors.name && <Field.ErrorText>{errors.name.message}</Field.ErrorText>}
+        </Field.Root>
+        <Field.Root invalid={!!errors.document}>
+          <Field.Label>Documento</Field.Label>
+          <Input {...register('document')} />
+          {errors.document && (
+            <Field.ErrorText>{errors.document.message}</Field.ErrorText>
+          )}
+        </Field.Root>
+        <Field.Root invalid={!!errors.billingGroupId}>
+          <Field.Label>Grupo</Field.Label>
+          <Input {...register('billingGroupId')} />
+          {errors.billingGroupId && (
+            <Field.ErrorText>{errors.billingGroupId.message}</Field.ErrorText>
+          )}
+        </Field.Root>
+        <Button type="submit" colorScheme="blue">
+          Salvar
+        </Button>
+      </Stack>
+    </form>
+  );
+}

--- a/src/app/(admin)/customers/[id]/page.tsx
+++ b/src/app/(admin)/customers/[id]/page.tsx
@@ -1,0 +1,36 @@
+'use client';
+import { Box } from '@chakra-ui/react';
+import { useRouter, useParams } from 'next/navigation';
+import CustomerForm, { CustomerFormData } from '../CustomerForm';
+import {
+  useGetCustomerQuery,
+  useUpdateCustomerMutation,
+} from '@/features/customers/customersApi';
+
+export default function EditCustomerPage() {
+  const params = useParams();
+  const id = params?.id as string;
+  const { data } = useGetCustomerQuery(id);
+  const [updateCustomer] = useUpdateCustomerMutation();
+  const router = useRouter();
+
+  const handleSubmit = async (form: CustomerFormData) => {
+    await updateCustomer({ id, data: form }).unwrap();
+    router.push('/customers');
+  };
+
+  if (!data) return null;
+
+  return (
+    <Box>
+      <CustomerForm
+        onSubmit={handleSubmit}
+        defaultValues={{
+          name: data.name,
+          document: data.document,
+          billingGroupId: data.billingGroupId,
+        }}
+      />
+    </Box>
+  );
+}

--- a/src/app/(admin)/customers/new/page.tsx
+++ b/src/app/(admin)/customers/new/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { Box } from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
+import CustomerForm, { CustomerFormData } from '../CustomerForm';
+import { useCreateCustomerMutation } from '@/features/customers/customersApi';
+
+export default function NewCustomerPage() {
+  const [createCustomer] = useCreateCustomerMutation();
+  const router = useRouter();
+
+  const handleSubmit = async (data: CustomerFormData) => {
+    await createCustomer(data).unwrap();
+    router.push('/customers');
+  };
+
+  return (
+    <Box>
+      <CustomerForm onSubmit={handleSubmit} />
+    </Box>
+  );
+}

--- a/src/app/(admin)/customers/page.tsx
+++ b/src/app/(admin)/customers/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+import { Box, Button } from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import DataTable from '@/components/DataTable';
+import Search from '@/components/Search';
+import PaginationAction from '@/components/PaginationAction';
+import {
+  useGetCustomersQuery,
+  useDeleteCustomerMutation,
+} from '@/features/customers/customersApi';
+
+export default function CustomersPage() {
+  const { data = [] } = useGetCustomersQuery();
+  const [deleteCustomer] = useDeleteCustomerMutation();
+  const router = useRouter();
+  const [page, setPage] = useState(1);
+  const pageSize = 10;
+  const totalCount = data.length;
+
+  return (
+    <Box position="relative">
+      <Search
+        options={[{ key: 'name', label: 'Nome' }]}
+        defaultKey="name"
+        onSearch={() => {}}
+      />
+      <DataTable
+        data={data.slice((page - 1) * pageSize, page * pageSize)}
+        options={[
+          { key: 'name', label: 'Nome' },
+          { key: 'document', label: 'Documento' },
+        ]}
+        onRowClick={(id) => router.push(`/customers/${id}`)}
+        onDelete={async (id) => {
+          await deleteCustomer(id);
+        }}
+        page={page}
+        pageSize={pageSize}
+        totalCount={totalCount}
+      />
+      <PaginationAction
+        page={page}
+        pageSize={pageSize}
+        totalCount={totalCount}
+        onPageChange={setPage}
+      />
+      <Button
+        position="fixed"
+        bottom="8"
+        right="8"
+        colorScheme="blue"
+        rounded="full"
+        onClick={() => router.push('/customers/new')}
+      >
+        +
+      </Button>
+    </Box>
+  );
+}

--- a/src/app/(admin)/customers/page.tsx
+++ b/src/app/(admin)/customers/page.tsx
@@ -26,11 +26,14 @@ export default function CustomersPage() {
         onSearch={() => {}}
       />
       <DataTable
-        data={data.slice((page - 1) * pageSize, page * pageSize)}
+        data={data
+          .slice((page - 1) * pageSize, page * pageSize)
+          .map((c) => c as unknown as Record<string, string>)}
         options={[
-          { key: 'name', label: 'Nome' },
-          { key: 'document', label: 'Documento' },
+          { key: 'name', columName: 'Nome' },
+          { key: 'document', columName: 'Documento' },
         ]}
+        keyExtractor={(c) => c.id}
         onRowClick={(id) => router.push(`/customers/${id}`)}
         onDelete={async (id) => {
           await deleteCustomer(id);

--- a/src/app/(admin)/settings/page.tsx
+++ b/src/app/(admin)/settings/page.tsx
@@ -133,7 +133,7 @@ function PartnerSection() {
                   type="button"
                   colorScheme="red"
                   onClick={handleDelete}
-                  isDisabled={!selected}
+                  disabled={!selected}
                 >
                   Remover
                 </Button>
@@ -258,7 +258,7 @@ function ProviderSection() {
                   type="button"
                   colorScheme="red"
                   onClick={handleDelete}
-                  isDisabled={!selected}
+                  disabled={!selected}
                 >
                   Remover
                 </Button>

--- a/src/app/(admin)/users/UserForm.tsx
+++ b/src/app/(admin)/users/UserForm.tsx
@@ -1,0 +1,53 @@
+'use client';
+import { Button, Field, Input, Stack } from '@chakra-ui/react';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as yup from 'yup';
+
+const schema = yup.object({
+  email: yup.string().required('Email é obrigatório').email(),
+  password: yup.string().notRequired(),
+});
+
+export type UserFormData = yup.InferType<typeof schema>;
+
+export default function UserForm({
+  defaultValues,
+  onSubmit,
+}: {
+  defaultValues?: Partial<UserFormData>;
+  onSubmit: (data: UserFormData) => void;
+}) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<UserFormData>({
+    resolver: yupResolver(schema),
+    defaultValues,
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Stack gap="4" maxW="sm">
+        <Field.Root invalid={!!errors.email}>
+          <Field.Label>Email</Field.Label>
+          <Input {...register('email')} />
+          {errors.email && (
+            <Field.ErrorText>{errors.email.message}</Field.ErrorText>
+          )}
+        </Field.Root>
+        <Field.Root invalid={!!errors.password}>
+          <Field.Label>Senha</Field.Label>
+          <Input type="password" {...register('password')} />
+          {errors.password && (
+            <Field.ErrorText>{errors.password.message}</Field.ErrorText>
+          )}
+        </Field.Root>
+        <Button type="submit" colorScheme="blue">
+          Salvar
+        </Button>
+      </Stack>
+    </form>
+  );
+}

--- a/src/app/(admin)/users/[id]/page.tsx
+++ b/src/app/(admin)/users/[id]/page.tsx
@@ -1,0 +1,29 @@
+'use client';
+import { Box } from '@chakra-ui/react';
+import { useRouter, useParams } from 'next/navigation';
+import UserForm, { UserFormData } from '../UserForm';
+import {
+  useGetUserQuery,
+  useUpdateUserMutation,
+} from '@/features/users/usersApi';
+
+export default function EditUserPage() {
+  const params = useParams();
+  const id = params?.id as string;
+  const { data } = useGetUserQuery(id);
+  const [updateUser] = useUpdateUserMutation();
+  const router = useRouter();
+
+  const handleSubmit = async (form: UserFormData) => {
+    await updateUser({ id, data: form }).unwrap();
+    router.push('/users');
+  };
+
+  if (!data) return null;
+
+  return (
+    <Box>
+      <UserForm onSubmit={handleSubmit} defaultValues={{ email: data.email }} />
+    </Box>
+  );
+}

--- a/src/app/(admin)/users/new/page.tsx
+++ b/src/app/(admin)/users/new/page.tsx
@@ -9,7 +9,7 @@ export default function NewUserPage() {
   const router = useRouter();
 
   const handleSubmit = async (data: UserFormData) => {
-    await createUser(data).unwrap();
+    await createUser({ email: data.email, password: data.password ?? '' }).unwrap();
     router.push('/users');
   };
 

--- a/src/app/(admin)/users/new/page.tsx
+++ b/src/app/(admin)/users/new/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { Box } from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
+import UserForm, { UserFormData } from '../UserForm';
+import { useCreateUserMutation } from '@/features/users/usersApi';
+
+export default function NewUserPage() {
+  const [createUser] = useCreateUserMutation();
+  const router = useRouter();
+
+  const handleSubmit = async (data: UserFormData) => {
+    await createUser(data).unwrap();
+    router.push('/users');
+  };
+
+  return (
+    <Box>
+      <UserForm onSubmit={handleSubmit} />
+    </Box>
+  );
+}

--- a/src/app/(admin)/users/page.tsx
+++ b/src/app/(admin)/users/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Box, Button } from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import DataTable from '@/components/DataTable';
+import Search from '@/components/Search';
+import PaginationAction from '@/components/PaginationAction';
+import {
+  useGetUsersQuery,
+  useDeleteUserMutation,
+} from '@/features/users/usersApi';
+
+export default function UsersPage() {
+  const { data = [] } = useGetUsersQuery();
+  const [deleteUser] = useDeleteUserMutation();
+  const router = useRouter();
+  const [page, setPage] = useState(1);
+  const pageSize = 10;
+  const totalCount = data.length;
+
+  return (
+    <Box position="relative">
+      <Search
+        options={[{ key: 'email', label: 'Email' }]}
+        defaultKey="email"
+        onSearch={() => {}}
+      />
+      <DataTable
+        data={data.slice((page - 1) * pageSize, page * pageSize)}
+        options={[{ key: 'email', label: 'Email' }]}
+        onRowClick={(id) => router.push(`/users/${id}`)}
+        onDelete={async (id) => {
+          await deleteUser(id);
+        }}
+        page={page}
+        pageSize={pageSize}
+        totalCount={totalCount}
+      />
+      <PaginationAction
+        page={page}
+        pageSize={pageSize}
+        totalCount={totalCount}
+        onPageChange={setPage}
+      />
+      <Button
+        position="fixed"
+        bottom="8"
+        right="8"
+        colorScheme="blue"
+        rounded="full"
+        onClick={() => router.push('/users/new')}
+      >
+        +
+      </Button>
+    </Box>
+  );
+}

--- a/src/app/(admin)/users/page.tsx
+++ b/src/app/(admin)/users/page.tsx
@@ -27,8 +27,11 @@ export default function UsersPage() {
         onSearch={() => {}}
       />
       <DataTable
-        data={data.slice((page - 1) * pageSize, page * pageSize)}
-        options={[{ key: 'email', label: 'Email' }]}
+        data={data
+          .slice((page - 1) * pageSize, page * pageSize)
+          .map((u) => u as unknown as Record<string, string>)}
+        options={[{ key: 'email', columName: 'Email' }]}
+        keyExtractor={(u) => u.id}
         onRowClick={(id) => router.push(`/users/${id}`)}
         onDelete={async (id) => {
           await deleteUser(id);

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -1,0 +1,67 @@
+import { Table, IconButton } from '@chakra-ui/react';
+import { FiTrash2 } from 'react-icons/fi';
+
+export interface DataTableOption {
+  key: string;
+  label: string;
+}
+
+export interface DataTableProps {
+  data: Array<Record<string, unknown>>;
+  options: DataTableOption[];
+  onRowClick: (id: string) => void;
+  onDelete: (id: string) => void;
+  selectedRows?: string[];
+  onPageChange?: (page: number) => void;
+  page: number;
+  pageSize: number;
+  totalCount: number;
+}
+
+export default function DataTable({
+  data,
+  options,
+  onRowClick,
+  onDelete,
+}: DataTableProps) {
+  return (
+    <Table.Root variant="simple">
+      <Table.Header>
+        <Table.Row>
+          {options.map((opt) => (
+            <Table.HeaderCell key={opt.key}>{opt.label}</Table.HeaderCell>
+          ))}
+          <Table.HeaderCell>Ações</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {data.map((row) => (
+          <Table.Row
+            key={row.id}
+            cursor="pointer"
+            _hover={{ bg: 'gray.50' }}
+            onClick={() => onRowClick(row.id)}
+          >
+            {options.map((opt) => (
+              <Table.Cell key={opt.key}>{row[opt.key]}</Table.Cell>
+            ))}
+            <Table.Cell>
+              <IconButton
+                aria-label="Excluir"
+                icon={<FiTrash2 />}
+                size="sm"
+                colorScheme="red"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (window.confirm('Confirma a exclusão?')) {
+                    onDelete(row.id);
+                  }
+                }}
+              />
+            </Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table.Root>
+  );
+}

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -3,12 +3,13 @@ import { FiTrash2 } from 'react-icons/fi';
 
 export interface DataTableOption {
   key: string;
-  label: string;
+  columName: string;
 }
 
-export interface DataTableProps {
-  data: Array<Record<string, unknown>>;
+export interface DataTableProps<T extends Record<string, string>> {
+  data: Array<T>;
   options: DataTableOption[];
+  keyExtractor: (item: T) => string;
   onRowClick: (id: string) => void;
   onDelete: (id: string) => void;
   selectedRows?: string[];
@@ -18,49 +19,54 @@ export interface DataTableProps {
   totalCount: number;
 }
 
-export default function DataTable({
+export default function DataTable<T extends Record<string, string>>({
   data,
   options,
+  keyExtractor,
   onRowClick,
   onDelete,
-}: DataTableProps) {
+}: DataTableProps<T>) {
   return (
-    <Table.Root variant="simple">
+    <Table.Root variant="line">
       <Table.Header>
         <Table.Row>
           {options.map((opt) => (
-            <Table.HeaderCell key={opt.key}>{opt.label}</Table.HeaderCell>
+            <Table.ColumnHeader key={opt.key}>{opt.columName}</Table.ColumnHeader>
           ))}
-          <Table.HeaderCell>Ações</Table.HeaderCell>
+          <Table.ColumnHeader>Ações</Table.ColumnHeader>
         </Table.Row>
       </Table.Header>
       <Table.Body>
-        {data.map((row) => (
-          <Table.Row
-            key={row.id}
-            cursor="pointer"
-            _hover={{ bg: 'gray.50' }}
-            onClick={() => onRowClick(row.id)}
-          >
-            {options.map((opt) => (
-              <Table.Cell key={opt.key}>{row[opt.key]}</Table.Cell>
-            ))}
+        {data.map((row) => {
+          const id = keyExtractor(row);
+          return (
+            <Table.Row
+              key={id}
+              cursor="pointer"
+              _hover={{ bg: 'gray.50' }}
+              onClick={() => onRowClick(id)}
+            >
+              {options.map((opt) => (
+                <Table.Cell key={`${id}-${row[opt.key]}`}>{row[opt.key]}</Table.Cell>
+              ))}
             <Table.Cell>
               <IconButton
                 aria-label="Excluir"
-                icon={<FiTrash2 />}
                 size="sm"
                 colorScheme="red"
                 onClick={(e) => {
                   e.stopPropagation();
                   if (window.confirm('Confirma a exclusão?')) {
-                    onDelete(row.id);
+                    onDelete(id);
                   }
                 }}
-              />
+              >
+                <FiTrash2 />
+              </IconButton>
             </Table.Cell>
-          </Table.Row>
-        ))}
+            </Table.Row>
+          );
+        })}
       </Table.Body>
     </Table.Root>
   );

--- a/src/components/PaginationAction.tsx
+++ b/src/components/PaginationAction.tsx
@@ -1,0 +1,30 @@
+import { Pagination } from '@chakra-ui/react';
+
+export interface PaginationActionProps {
+  page: number;
+  pageSize: number;
+  totalCount: number;
+  onPageChange: (page: number) => void;
+}
+
+export default function PaginationAction({
+  page,
+  pageSize,
+  totalCount,
+  onPageChange,
+}: PaginationActionProps) {
+  return (
+    <Pagination.Root
+      page={page}
+      onPageChange={(d) => onPageChange(d.page)}
+      count={totalCount}
+      pageSize={pageSize}
+      showPageJump
+    >
+      <Pagination.PrevTrigger />
+      <Pagination.Items />
+      <Pagination.NextTrigger />
+      <Pagination.PageText ml="2" />
+    </Pagination.Root>
+  );
+}

--- a/src/components/PaginationAction.tsx
+++ b/src/components/PaginationAction.tsx
@@ -19,10 +19,12 @@ export default function PaginationAction({
       onPageChange={(d) => onPageChange(d.page)}
       count={totalCount}
       pageSize={pageSize}
-      showPageJump
     >
       <Pagination.PrevTrigger />
-      <Pagination.Items />
+      <Pagination.Items
+        render={(page) => <Pagination.Item {...page} />}
+        ellipsis={<Pagination.Ellipsis index={0} />}
+      />
       <Pagination.NextTrigger />
       <Pagination.PageText ml="2" />
     </Pagination.Root>

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,0 +1,59 @@
+import { useState, useEffect } from 'react';
+import { Input, Select, Button, Flex } from '@chakra-ui/react';
+
+export interface SearchOption {
+  key: string;
+  label: string;
+}
+
+export interface SearchProps {
+  options: SearchOption[];
+  defaultKey: string;
+  onSearch: (payload: { key: string; term: string }) => void;
+}
+
+export default function Search({ options, defaultKey, onSearch }: SearchProps) {
+  const [key, setKey] = useState(defaultKey);
+  const [term, setTerm] = useState('');
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      if (term) {
+        onSearch({ key, term });
+      }
+    }, 500);
+    return () => clearTimeout(handler);
+  }, [key, term, onSearch]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSearch({ key, term });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Flex gap="2">
+        <Select value={key} onChange={(e) => setKey(e.target.value)} w="auto">
+          {options.map((o) => (
+            <option key={o.key} value={o.key}>
+              {o.label}
+            </option>
+          ))}
+        </Select>
+        <Input
+          value={term}
+          onChange={(e) => setTerm(e.target.value)}
+          placeholder="Buscar"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              handleSubmit(e);
+            }
+          }}
+        />
+        <Button type="submit" colorScheme="blue">
+          Buscar
+        </Button>
+      </Flex>
+    </form>
+  );
+}

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Input, Select, Button, Flex } from '@chakra-ui/react';
+import { Input, Button, Flex, NativeSelect } from '@chakra-ui/react';
 
 export interface SearchOption {
   key: string;
@@ -33,13 +33,19 @@ export default function Search({ options, defaultKey, onSearch }: SearchProps) {
   return (
     <form onSubmit={handleSubmit}>
       <Flex gap="2">
-        <Select value={key} onChange={(e) => setKey(e.target.value)} w="auto">
-          {options.map((o) => (
-            <option key={o.key} value={o.key}>
-              {o.label}
-            </option>
-          ))}
-        </Select>
+        <NativeSelect.Root>
+          <NativeSelect.Field
+            value={key}
+            onChange={(e) => setKey(e.target.value)}
+            w="auto"
+          >
+            {options.map((o) => (
+              <option key={o.key} value={o.key}>
+                {o.label}
+              </option>
+            ))}
+          </NativeSelect.Field>
+        </NativeSelect.Root>
         <Input
           value={term}
           onChange={(e) => setTerm(e.target.value)}

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -40,6 +40,15 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
           <Link asChild color={pathname === "/dashboard" ? "blue.600" : undefined}>
             <NextLink href="/dashboard">Dashboard</NextLink>
           </Link>
+          <Link asChild color={pathname.startsWith("/users") ? "blue.600" : undefined}>
+            <NextLink href="/users">Usuários</NextLink>
+          </Link>
+          <Link asChild color={pathname.startsWith("/customers") ? "blue.600" : undefined}>
+            <NextLink href="/customers">Clientes</NextLink>
+          </Link>
+          <Link asChild color={pathname.startsWith("/billing-groups") ? "blue.600" : undefined}>
+            <NextLink href="/billing-groups">Grupos de Cobrança</NextLink>
+          </Link>
           <Link asChild color={pathname.startsWith("/settings") ? "blue.600" : undefined}>
             <NextLink href="/settings">Configuração</NextLink>
           </Link>

--- a/src/features/billingGroups/billingGroupsApi.ts
+++ b/src/features/billingGroups/billingGroupsApi.ts
@@ -1,0 +1,68 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import type { RootState } from '@/store';
+
+export interface BillingGroup {
+  id: string;
+  baseAmount: number;
+  dueDay: number;
+  finePercent: number;
+  interestPercentMonth: number;
+  createdBy?: string;
+}
+
+export const billingGroupsApi = createApi({
+  reducerPath: 'billingGroupsApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: 'http://localhost:3333/v1',
+    prepareHeaders: (headers, { getState }) => {
+      const state = getState() as RootState;
+      const token = state.auth.token;
+      if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+      }
+      return headers;
+    },
+  }),
+  tagTypes: ['BillingGroup'],
+  endpoints: (builder) => ({
+    getBillingGroups: builder.query<BillingGroup[], void>({
+      query: () => 'billing-groups',
+      providesTags: ['BillingGroup'],
+    }),
+    getBillingGroup: builder.query<BillingGroup, string>({
+      query: (id) => `billing-groups/${id}`,
+      providesTags: (_r, _e, id) => [{ type: 'BillingGroup', id }],
+    }),
+    createBillingGroup: builder.mutation<BillingGroup, Omit<BillingGroup, 'id'>>({
+      query: (body) => ({
+        url: 'billing-groups',
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: ['BillingGroup'],
+    }),
+    updateBillingGroup: builder.mutation<BillingGroup, { id: string; data: Partial<BillingGroup> }>({
+      query: ({ id, data }) => ({
+        url: `billing-groups/${id}`,
+        method: 'PUT',
+        body: data,
+      }),
+      invalidatesTags: ['BillingGroup'],
+    }),
+    deleteBillingGroup: builder.mutation<void, string>({
+      query: (id) => ({
+        url: `billing-groups/${id}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: ['BillingGroup'],
+    }),
+  }),
+});
+
+export const {
+  useGetBillingGroupsQuery,
+  useGetBillingGroupQuery,
+  useCreateBillingGroupMutation,
+  useUpdateBillingGroupMutation,
+  useDeleteBillingGroupMutation,
+} = billingGroupsApi;

--- a/src/features/customers/customersApi.ts
+++ b/src/features/customers/customersApi.ts
@@ -1,0 +1,66 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import type { RootState } from '@/store';
+
+export interface Customer {
+  id: string;
+  name: string;
+  document: string;
+  billingGroupId: string;
+}
+
+export const customersApi = createApi({
+  reducerPath: 'customersApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: 'http://localhost:3333/v1',
+    prepareHeaders: (headers, { getState }) => {
+      const state = getState() as RootState;
+      const token = state.auth.token;
+      if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+      }
+      return headers;
+    },
+  }),
+  tagTypes: ['Customer'],
+  endpoints: (builder) => ({
+    getCustomers: builder.query<Customer[], void>({
+      query: () => 'customers',
+      providesTags: ['Customer'],
+    }),
+    getCustomer: builder.query<Customer, string>({
+      query: (id) => `customers/${id}`,
+      providesTags: (_r, _e, id) => [{ type: 'Customer', id }],
+    }),
+    createCustomer: builder.mutation<Customer, Omit<Customer, 'id'>>({
+      query: (body) => ({
+        url: 'customers',
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: ['Customer'],
+    }),
+    updateCustomer: builder.mutation<Customer, { id: string; data: Partial<Customer> }>({
+      query: ({ id, data }) => ({
+        url: `customers/${id}`,
+        method: 'PUT',
+        body: data,
+      }),
+      invalidatesTags: ['Customer'],
+    }),
+    deleteCustomer: builder.mutation<void, string>({
+      query: (id) => ({
+        url: `customers/${id}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: ['Customer'],
+    }),
+  }),
+});
+
+export const {
+  useGetCustomersQuery,
+  useGetCustomerQuery,
+  useCreateCustomerMutation,
+  useUpdateCustomerMutation,
+  useDeleteCustomerMutation,
+} = customersApi;

--- a/src/features/users/usersApi.ts
+++ b/src/features/users/usersApi.ts
@@ -1,0 +1,66 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import type { RootState } from '@/store';
+
+export interface User {
+  id: string;
+  email: string;
+}
+
+export const usersApi = createApi({
+  reducerPath: 'usersApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: 'http://localhost:3333/v1',
+    prepareHeaders: (headers, { getState }) => {
+      const state = getState() as RootState;
+      const token = state.auth.token;
+      if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+      }
+      return headers;
+    },
+  }),
+  tagTypes: ['User'],
+  endpoints: (builder) => ({
+    getUsers: builder.query<User[], void>({
+      query: () => 'users',
+      providesTags: ['User'],
+    }),
+    getUser: builder.query<User, string>({
+      query: (id) => `users/${id}`,
+      providesTags: (_r, _e, id) => [{ type: 'User', id }],
+    }),
+    createUser: builder.mutation<User, Pick<User, 'email'> & { password: string }>(
+      {
+        query: (body) => ({
+          url: 'users',
+          method: 'POST',
+          body,
+        }),
+        invalidatesTags: ['User'],
+      }
+    ),
+    updateUser: builder.mutation<User, { id: string; data: Partial<User> }>({
+      query: ({ id, data }) => ({
+        url: `users/${id}`,
+        method: 'PUT',
+        body: data,
+      }),
+      invalidatesTags: ['User'],
+    }),
+    deleteUser: builder.mutation<void, string>({
+      query: (id) => ({
+        url: `users/${id}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: ['User'],
+    }),
+  }),
+});
+
+export const {
+  useGetUsersQuery,
+  useGetUserQuery,
+  useCreateUserMutation,
+  useUpdateUserMutation,
+  useDeleteUserMutation,
+} = usersApi;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,6 +3,9 @@ import authReducer from '@/features/auth/authSlice';
 import { authApi } from '@/features/auth/authApi';
 import appReducer from '@/features/app/appSlice';
 import { settingsApi } from '@/features/settings/settingsApi';
+import { usersApi } from '@/features/users/usersApi';
+import { customersApi } from '@/features/customers/customersApi';
+import { billingGroupsApi } from '@/features/billingGroups/billingGroupsApi';
 
 export const store = configureStore({
   reducer: {
@@ -10,9 +13,18 @@ export const store = configureStore({
     app: appReducer,
     [authApi.reducerPath]: authApi.reducer,
     [settingsApi.reducerPath]: settingsApi.reducer,
+    [usersApi.reducerPath]: usersApi.reducer,
+    [customersApi.reducerPath]: customersApi.reducer,
+    [billingGroupsApi.reducerPath]: billingGroupsApi.reducer,
   },
   middleware: (gDM) =>
-    gDM().concat(authApi.middleware, settingsApi.middleware),
+    gDM().concat(
+      authApi.middleware,
+      settingsApi.middleware,
+      usersApi.middleware,
+      customersApi.middleware,
+      billingGroupsApi.middleware,
+    ),
 });
 
 export type RootState = ReturnType<typeof store.getState>;


### PR DESCRIPTION
## Summary
- implement `DataTable`, `Search`, and `PaginationAction` components
- create RTK Query APIs for users, customers and billing groups
- add CRUD pages with forms for each entity
- hook new APIs into the store
- update dashboard navigation links

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686eb8b615d88332b32db580e81b6e14